### PR TITLE
Fix cec-notifier.c path

### DIFF
--- a/backports/v3.1_no_export_h.patch
+++ b/backports/v3.1_no_export_h.patch
@@ -1,7 +1,7 @@
 diff --git a/drivers/media/cec-notifier.c b/drivers/media/cec-notifier.c
 index 5f5209a73665..894399639fe5 100644
---- a/drivers/media/cec-notifier.c
-+++ b/drivers/media/cec-notifier.c
+--- a/drivers/media/cec/cec-notifier.c
++++ b/drivers/media/cec/cec-notifier.c
 @@ -18,7 +18,6 @@
   * SOFTWARE.
   */


### PR DESCRIPTION
Build on older kernels will fail due to wrong path.