### PR TITLE
Merge instead of rebase when pulling latest

### DIFF
--- a/build
+++ b/build
@@ -520,10 +520,10 @@ if (@git == 2) {
 	print "************************************************************\n";
 	license;
 
-	#print "****************************\n";
-	#print "Updating the building system\n";
-	#print "****************************\n";
-	#system("git pull https://github.com/tbsdtv/media_build.git latest");
+	print "****************************\n";
+	print "Updating the building system\n";
+	print "****************************\n";
+	system("git pull --rebase=false https://github.com/tbsdtv/media_build.git latest");
 
 	run("make -C linux/ download", "Download failed");
 	run("make -C linux/ untar", "Untar failed");


### PR DESCRIPTION
This is a fix for tbsdtv/media_build#335. I have `pull.rebase=true` set as the default, which needs to be
explicitly overridden.