### PR TITLE
Split vm_flags_set() backports in a separate patch

### DIFF
--- a/backports/backports.txt
+++ b/backports/backports.txt
@@ -57,6 +57,7 @@ add v6.2_remove.patch
 add v6.2_probe.patch
 add v6.2_probe_tbs.patch
 add v6.2_v4l2-core.patch
+add v6.2_vm_flags_set.patch
 
 [6.1.1023]
 add v6.1_class.patch

--- a/backports/v6.2_v4l2-core.patch
+++ b/backports/v6.2_v4l2-core.patch
@@ -134,29 +134,3 @@ index 049c2f2001ea..3d9533c1b202 100644
  	v4l2_async_nf_cleanup(notifier);
  	kfree(notifier);
  
-diff --git a/drivers/media/common/videobuf2/videobuf2-dma-contig.c b/drivers/media/common/videobuf2/videobuf2-dma-contig.c
-index 205d3cac425c..d14e13385385 100644
---- a/drivers/media/common/videobuf2/videobuf2-dma-contig.c
-+++ b/drivers/media/common/videobuf2/videobuf2-dma-contig.c
-@@ -293,7 +293,7 @@ static int vb2_dc_mmap(void *buf_priv, struct vm_area_struct *vma)
- 		return ret;
- 	}
- 
--	vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
-+	vma->vm_flags |= VM_DONTEXPAND | VM_DONTDUMP;
- 	vma->vm_private_data	= &buf->handler;
- 	vma->vm_ops		= &vb2_common_vm_ops;
- 
-diff --git a/drivers/media/common/videobuf2/videobuf2-vmalloc.c b/drivers/media/common/videobuf2/videobuf2-vmalloc.c
-index a6c6d2fcaaa4..ff9496582900 100644
---- a/drivers/media/common/videobuf2/videobuf2-vmalloc.c
-+++ b/drivers/media/common/videobuf2/videobuf2-vmalloc.c
-@@ -185,7 +185,7 @@ static int vb2_vmalloc_mmap(void *buf_priv, struct vm_area_struct *vma)
- 	/*
- 	 * Make sure that vm_areas for 2 buffers won't be merged together
- 	 */
--	vm_flags_set(vma, VM_DONTEXPAND);
-+	vma->vm_flags |= VM_DONTEXPAND;
- 
- 	/*
- 	 * Use common vm_area operations to track buffer refcount.

--- a/backports/v6.2_vm_flags_set.patch
+++ b/backports/v6.2_vm_flags_set.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/media/common/videobuf2/videobuf2-dma-contig.c b/drivers/media/common/videobuf2/videobuf2-dma-contig.c
+index 205d3cac425c..d14e13385385 100644
+--- a/drivers/media/common/videobuf2/videobuf2-dma-contig.c
++++ b/drivers/media/common/videobuf2/videobuf2-dma-contig.c
+@@ -293,7 +293,7 @@ static int vb2_dc_mmap(void *buf_priv, struct vm_area_struct *vma)
+ 		return ret;
+ 	}
+ 
+-	vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
++	vma->vm_flags |= VM_DONTEXPAND | VM_DONTDUMP;
+ 	vma->vm_private_data	= &buf->handler;
+ 	vma->vm_ops		= &vb2_common_vm_ops;
+ 
+diff --git a/drivers/media/common/videobuf2/videobuf2-vmalloc.c b/drivers/media/common/videobuf2/videobuf2-vmalloc.c
+index a6c6d2fcaaa4..ff9496582900 100644
+--- a/drivers/media/common/videobuf2/videobuf2-vmalloc.c
++++ b/drivers/media/common/videobuf2/videobuf2-vmalloc.c
+@@ -185,7 +185,7 @@ static int vb2_vmalloc_mmap(void *buf_priv, struct vm_area_struct *vma)
+ 	/*
+ 	 * Make sure that vm_areas for 2 buffers won't be merged together
+ 	 */
+-	vm_flags_set(vma, VM_DONTEXPAND);
++	vma->vm_flags |= VM_DONTEXPAND;
+ 
+ 	/*
+ 	 * Use common vm_area operations to track buffer refcount.


### PR DESCRIPTION
This makes building with RHEL 9.5 and derivative easier as we only need to comment some patches in backports.txt.