### PR TITLE
fix(ccs): handle 1-param pm_runtime_get_if_active (issue #92)

### DIFF
--- a/v4l/compat.h
+++ b/v4l/compat.h
@@ -1310,4 +1310,14 @@ static inline int dma_mmap_noncontiguous(struct device *dev,
 #define dev_is_platform(dev) ((dev)->bus == &platform_bus_type)
 #endif
 
+/* v6.8-ccs.patch uses the 2-param form of pm_runtime_get_if_active(dev, flag).
+ * Some distributions (e.g. Ubuntu 6.8) backport the 1-param form from 6.9+.
+ * Use a variadic macro to drop the second argument when the kernel only
+ * exposes the 1-param API.  The (pm_runtime_get_if_active) notation prevents
+ * recursive macro expansion.
+ */
+#ifdef NEED_PM_RUNTIME_GET_IF_ACTIVE_WRAPPER
+#define pm_runtime_get_if_active(dev, ...) (pm_runtime_get_if_active)(dev)
+#endif
+
 #endif /*  _COMPAT_H */

--- a/v4l/scripts/make_config_compat.pl
+++ b/v4l/scripts/make_config_compat.pl
@@ -81,6 +81,7 @@ sub check_other_dependencies()
 	check_files_for_func("is_of_node", "NEED_IS_OF_NODE", "include/linux/of.h");
 	check_files_for_func("skb_put_data", "NEED_SKB_PUT_DATA", "include/linux/skbuff.h");
 	check_files_for_func("pm_runtime_get_if_in_use", "NEED_PM_RUNTIME_GET", "include/linux/pm_runtime.h");
+	check_files_for_func("pm_runtime_get_if_active[^)]*bool", "NEED_PM_RUNTIME_GET_IF_ACTIVE_WRAPPER", "include/linux/pm_runtime.h");
 	check_files_for_func("KEY_APPSELECT", "NEED_KEY_APPSELECT", "include/uapi/linux/input-event-codes.h");
 	check_files_for_func("PCI_DEVICE_SUB", "NEED_PCI_DEVICE_SUB", "include/linux/pci.h");
 	check_files_for_func("U32_MAX", "NEED_U32_MAX", "include/linux/kernel.h", "include/linux/limits.h");


### PR DESCRIPTION
# fix(ccs): handle 1-param pm_runtime_get_if_active (issue #92)

Fixes #92

## Problem

`v6.8-ccs.patch` changes `pm_runtime_get_if_active()` to its 2-param form for
kernels ≤ 6.8. This is correct for mainline kernels 5.6–6.8, which introduced
the `bool ign_usage_count` parameter.

However, some distributions backport the **simplified 1-param form** from
kernel 6.9+ to their 6.8 kernel (e.g. Ubuntu 6.8). On those kernels the patched
2-param call fails to compile:

```
error: too many arguments to function 'pm_runtime_get_if_active'
```

## Fix

Detect which variant the kernel exposes by matching the prototype pattern
`pm_runtime_get_if_active[^)]*bool` in `include/linux/pm_runtime.h` via
`make_config_compat.pl`. This matches on the presence of a `bool` second
parameter rather than a specific parameter name, making the check robust
across vendor/backport trees that may rename the parameter:

```c
/* mainline 5.6–6.8: pattern matches → no wrapper needed */
extern int pm_runtime_get_if_active(struct device *dev, bool ign_usage_count);

/* 6.9+ and distros that backport the simplification: no match → wrapper needed */
extern int pm_runtime_get_if_active(struct device *dev);
```

When the pattern is **absent** (1-param kernel), `NEED_PM_RUNTIME_GET_IF_ACTIVE_WRAPPER`
is defined and `compat.h` provides a variadic macro that drops the second argument:

```c
#ifdef NEED_PM_RUNTIME_GET_IF_ACTIVE_WRAPPER
#define pm_runtime_get_if_active(dev, ...) (pm_runtime_get_if_active)(dev)
#endif
```

The `(pm_runtime_get_if_active)` notation prevents recursive macro expansion.
A macro is used instead of a `static inline` wrapper because `compat.h` is
force-included before kernel headers, so the function is not yet declared at
that point.

`v6.8-ccs.patch` and `v5.6_pm_runtime_get_if_active.patch` are left unchanged.

## Testing

Verified that the build completes without errors on Ubuntu 6.8.0-107-generic,
which ships the 1-param variant of `pm_runtime_get_if_active`.
